### PR TITLE
Improve packer-aws.json

### DIFF
--- a/dev/packer-aws.json
+++ b/dev/packer-aws.json
@@ -6,8 +6,6 @@
  },
   "builders": [{
     "type": "amazon-ebs",
-    "access_key": "{{user `aws_access_key`}}",
-    "secret_key": "{{user `aws_secret_key`}}",
     "region": "eu-west-1",
     "ami_groups": "all",
     "source_ami_filter": {
@@ -31,14 +29,7 @@
    "provisioners": [
     {
       "type": "shell",
-      "execute_command": "echo '{{user `ssh_pass`}}' | {{ .Vars }} sudo -E -S sh '{{ .Path }}'",
-      "inline":[
-        "echo '%sudo    ALL=(ALL)  NOPASSWD:ALL' >> /etc/sudoers"
-     ]
-    },
-    {
-      "type": "shell",
-      "execute_command" : "echo '{{user `ssh_pass`}}' | {{ .Vars }} sudo -E -S sh '{{ .Path }}'",
+      "execute_command" : "{{ .Vars }} sudo -E sh '{{ .Path }}'",
       "script": "/home/ubuntu/misp/bootstrap",
       "pause_before": "10s"
     }


### PR DESCRIPTION
- AWS access keys are no longer needed since the keys from the AWS profile are used
- set  instance type to micro (as used in the documentation)
- no need to change `/etc/sudoers`, that's already taken care of by cloud-init in `/etc/sudoers.d/90-cloud-init-users`
- no need to pass in a password, sudo is setup with NOPASSWD